### PR TITLE
Test with Go 1.21 only

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -1,16 +1,14 @@
 #
 # Copyright (c) 2023 Red Hat, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not
-# use this file except in compliance with the License. You may obtain a copy
-# of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations under
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 #
 
@@ -24,12 +22,8 @@ on:
 jobs:
 
   test:
-    name: Test
+    name: Unit tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go:
-        - '1.21'
     steps:
     - name: Checkout the source
       uses: actions/checkout@v3
@@ -37,7 +31,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: ${{ matrix.go }}
+        go-version: '1.21'
 
     - name: Install Go tools
       run: |
@@ -85,3 +79,4 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.54.2
+        args: --timeout=5m

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,17 +1,15 @@
 #
-# Copyright (c) 2021 Red Hat, Inc.
+# Copyright (c) 2023 Red Hat, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
 #
 
 # This file lists the Python dependencies used by the GitHub actions.


### PR DESCRIPTION
This patch changes the GitHub actions so that the project is tested only with Go 1.21.