### PR TITLE
Add action to publish image after merge

### DIFF
--- a/.github/workflows/closed-pull-request.yaml
+++ b/.github/workflows/closed-pull-request.yaml
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+name: Closed pull request
+
+on:
+  pull_request:
+    branches:
+    - main
+    types:
+    - closed
+
+jobs:
+
+  publish-image:
+    name: Publish image
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+    - name: Quay login
+      run: |
+        podman login \
+        --username "${{ secrets.QUAY_USER }}" \
+        --password "${{ secrets.QUAY_TOKEN }}" \
+        quay.io
+
+    - name: Checkout the source
+      uses: actions/checkout@v3
+
+    - name: Build and push the image
+      run: |
+        make \
+        image_repo="quay.io/jhernand/o2ims" \
+        image_tag="$(git rev-parse --short HEAD)" \
+        image push
+
+    - name: Quay logout
+      if: always()
+      run: |
+        podman logout


### PR DESCRIPTION
This patch adds a GitHub action that builds and pushes the container imagge to quay.io after the pull request is merged.