### PR TITLE
Allow passing command line arguments to container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -60,4 +60,4 @@ COPY \
  /home/builder/o2ims /usr/bin/o2ims
 
 ENTRYPOINT \
-  /usr/bin/o2ims
+  ["/usr/bin/o2ims"]


### PR DESCRIPTION
This patch changes the `ENTRYPOINT` of the image to use the _exec_ form, so that it can receive command line arguments.